### PR TITLE
APD-14040: Escape reserved key

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -213,8 +213,7 @@ public class MergeQueries {
     final String value = INTERMEDIATE_TABLE_VALUE_FIELD_NAME;
     final String batch = INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD;
 
-
-    String sql = "MERGE " + table(destinationTable) + " "
+    return "MERGE " + table(destinationTable) + " "
         + "USING ("
           + "SELECT * FROM ("
             + "SELECT ARRAY_AGG("
@@ -242,11 +241,6 @@ public class MergeQueries {
             + partitionTimeValue()
             + valueColumns.stream().map(col -> "src." + value + "." + col).collect(Collectors.joining(", "))
         + ");";
-
-    System.out.println("query::::" + sql);
-
-    return sql;
-
   }
 
   /*

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -226,16 +226,14 @@ public class MergeQueries {
         + ") "
         + "ON `" + destinationTable.getTable() + "`." + keyFieldName + "=src." + key + " "
         + "WHEN MATCHED AND src." + value + " IS NOT NULL "
-          + "THEN UPDATE SET " + valueColumns.stream().map(col -> "`" +col + "`" +"=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
+          + "THEN UPDATE SET " + valueColumns.stream().map(col -> "`" + col + "`" + "=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
         + "WHEN MATCHED AND src." + value + " IS NULL "
           + "THEN DELETE "
         + "WHEN NOT MATCHED AND src." + value + " IS NOT NULL "
           + "THEN INSERT ("
             + keyFieldName + ", "
             + partitionTimePseudoColumn()
-            + "`"
-            + String.join("`, `", valueColumns)
-            + "`) "
+            + "`" + String.join("`, `", valueColumns) + "`) "
           + "VALUES ("
             + "src." + key + ", "
             + partitionTimeValue()

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -213,7 +213,8 @@ public class MergeQueries {
     final String value = INTERMEDIATE_TABLE_VALUE_FIELD_NAME;
     final String batch = INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD;
 
-    return "MERGE " + table(destinationTable) + " "
+
+    String sql = "MERGE " + table(destinationTable) + " "
         + "USING ("
           + "SELECT * FROM ("
             + "SELECT ARRAY_AGG("
@@ -226,19 +227,26 @@ public class MergeQueries {
         + ") "
         + "ON `" + destinationTable.getTable() + "`." + keyFieldName + "=src." + key + " "
         + "WHEN MATCHED AND src." + value + " IS NOT NULL "
-          + "THEN UPDATE SET " + valueColumns.stream().map(col -> col + "=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
+          + "THEN UPDATE SET " + valueColumns.stream().map(col -> "`" +col + "`" +"=src." + value + "." + col).collect(Collectors.joining(", ")) + " "
         + "WHEN MATCHED AND src." + value + " IS NULL "
           + "THEN DELETE "
         + "WHEN NOT MATCHED AND src." + value + " IS NOT NULL "
           + "THEN INSERT ("
             + keyFieldName + ", "
             + partitionTimePseudoColumn()
-            + String.join(", ", valueColumns) + ") "
+            + "`"
+            + String.join("`, `", valueColumns)
+            + "`) "
           + "VALUES ("
             + "src." + key + ", "
             + partitionTimeValue()
             + valueColumns.stream().map(col -> "src." + value + "." + col).collect(Collectors.joining(", "))
         + ");";
+
+    System.out.println("query::::" + sql);
+
+    return sql;
+
   }
 
   /*


### PR DESCRIPTION
https://nexttrucking.atlassian.net/browse/APD-14040

Tested on dev, the fix working fine and able to load the `wiz_data_dictionary` table into bq
https://console.cloud.google.com/bigquery?project=next-data-dev&p=next-data-dev&d=qili_test&page=table&t=wiz_data_dictionary

before the fix, the merge query is 

MERGE `qili_test`.`wiz_data_dictionary` USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src FROM `qili_test`.`wiz_data_dictionary_tmp_0_4d6a3be2_fd9e_451e_8079_cfc00500048a_1612820898969` x WHERE batchNumber=0 GROUP BY key.id)) ON `wiz_data_dictionary`.__kafka_key=src.key 
WHEN MATCHED AND src.value IS NOT NULL THEN UPDATE SET id=src.value.id, key=src.value.key, name=src.value.name, order=src.value.order, biz_identity=src.value.biz_identity, comment=src.value.comment, status=src.value.status, created_by=src.value.created_by, created_date=src.value.created_date, last_modified_by=src.value.last_modified_by, last_modified_date=src.value.last_modified_date 
WHEN MATCHED AND src.value IS NULL THEN DELETE WHEN NOT MATCHED AND src.value IS NOT NULL THEN INSERT (__kafka_key, _PARTITIONTIME, id, key, name, order, biz_identity, comment, status, created_by, created_date, last_modified_by, last_modified_date) VALUES (src.key, CAST(CAST(DATE(src.partitionTime) AS DATE) AS TIMESTAMP), src.value.id, src.value.key, src.value.name, src.value.order, src.value.biz_identity, src.value.comment, src.value.status, src.value.created_by, src.value.created_date, src.value.last_modified_by, src.value.last_modified_date);


after the fix, the merge query is:

MERGE `qili_test`.`wiz_data_dictionary` USING (SELECT * FROM (SELECT ARRAY_AGG(x ORDER BY i DESC LIMIT 1)[OFFSET(0)] src FROM `qili_test`.`wiz_data_dictionary_tmp_0_5e1d72e5_d933_494f_bf59_cb8b43b19c00_1612820450137` x WHERE batchNumber=0 GROUP BY key.id)) ON `wiz_data_dictionary`.__kafka_key=src.key 
WHEN MATCHED AND src.value IS NOT NULL THEN UPDATE SET `id`=src.value.id, `key`=src.value.key, `name`=src.value.name, `order`=src.value.order, `biz_identity`=src.value.biz_identity, `comment`=src.value.comment, `status`=src.value.status, `created_by`=src.value.created_by, `created_date`=src.value.created_date, `last_modified_by`=src.value.last_modified_by, `last_modified_date`=src.value.last_modified_date
WHEN MATCHED AND src.value IS NULL THEN DELETE WHEN NOT MATCHED AND src.value IS NOT NULL THEN INSERT (__kafka_key, _PARTITIONTIME, `id`, `key`, `name`, `order`, `biz_identity`, `comment`, `status`, `created_by`, `created_date`, `last_modified_by`, `last_modified_date`) VALUES (src.key, CAST(CAST(DATE(src.partitionTime) AS DATE) AS TIMESTAMP), src.value.id, src.value.key, src.value.name, src.value.order, src.value.biz_identity, src.value.comment, src.value.status, src.value.created_by, src.value.created_date, src.value.last_modified_by, src.value.last_modified_date);
