### PR TITLE
add skipInvalidRows flag

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -31,6 +31,7 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -31,7 +31,6 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
-import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
@@ -351,7 +350,7 @@ public class BigQuerySinkTask extends SinkTask {
     boolean allowRequiredFieldRelaxation = config.getBoolean(config.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
     int retry = config.getInt(config.BIGQUERY_RETRY_CONFIG);
     long retryWait = config.getLong(config.BIGQUERY_RETRY_WAIT_CONFIG);
-    boolean skipFailedRows = config.getBoolean(config.SKIP_FAILED_ROWS_CONFIG);
+    boolean skipFailedRows = config.getBoolean(config.SKIP_INVALID_ROWS_CONFIG);
 
     BigQuery bigQuery = getBigQuery();
     if (upsertDelete) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -351,6 +351,8 @@ public class BigQuerySinkTask extends SinkTask {
     boolean allowRequiredFieldRelaxation = config.getBoolean(config.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
     int retry = config.getInt(config.BIGQUERY_RETRY_CONFIG);
     long retryWait = config.getLong(config.BIGQUERY_RETRY_WAIT_CONFIG);
+    boolean skipInvalidRows = config.getBoolean(config.SKIP_INVALID_ROWS_CONFIG);
+
     BigQuery bigQuery = getBigQuery();
     if (upsertDelete) {
       return new UpsertDeleteBigQueryWriter(bigQuery,
@@ -358,13 +360,15 @@ public class BigQuerySinkTask extends SinkTask {
                                             retry,
                                             retryWait,
                                             autoCreateTables,
-                                            mergeBatches.intermediateToDestinationTables());
+                                            mergeBatches.intermediateToDestinationTables(),
+                                            skipInvalidRows);
     } else if (autoCreateTables || allowNewBigQueryFields || allowRequiredFieldRelaxation) {
       return new AdaptiveBigQueryWriter(bigQuery,
                                         getSchemaManager(),
                                         retry,
                                         retryWait,
-                                        autoCreateTables);
+                                        autoCreateTables,
+                                        skipInvalidRows);
     } else {
       return new SimpleBigQueryWriter(bigQuery, retry, retryWait);
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -351,7 +351,7 @@ public class BigQuerySinkTask extends SinkTask {
     boolean allowRequiredFieldRelaxation = config.getBoolean(config.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
     int retry = config.getInt(config.BIGQUERY_RETRY_CONFIG);
     long retryWait = config.getLong(config.BIGQUERY_RETRY_WAIT_CONFIG);
-    boolean skipFailedRows = config.getBoolean(config.SKIP_INVALID_ROWS_CONFIG);
+    boolean skipInvalidRows = config.getBoolean(config.SKIP_INVALID_ROWS_CONFIG);
 
     BigQuery bigQuery = getBigQuery();
     if (upsertDelete) {
@@ -361,16 +361,16 @@ public class BigQuerySinkTask extends SinkTask {
                                             retryWait,
                                             autoCreateTables,
                                             mergeBatches.intermediateToDestinationTables(),
-                                            skipFailedRows);
+                                            skipInvalidRows);
     } else if (autoCreateTables || allowNewBigQueryFields || allowRequiredFieldRelaxation) {
       return new AdaptiveBigQueryWriter(bigQuery,
                                         getSchemaManager(),
                                         retry,
                                         retryWait,
                                         autoCreateTables,
-                                        skipFailedRows);
+                                        skipInvalidRows);
     } else {
-      return new SimpleBigQueryWriter(bigQuery, retry, retryWait, skipFailedRows);
+      return new SimpleBigQueryWriter(bigQuery, retry, retryWait, skipInvalidRows);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -31,7 +31,6 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
-import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.SinkConfigConnectException;
 import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
@@ -351,7 +350,7 @@ public class BigQuerySinkTask extends SinkTask {
     boolean allowRequiredFieldRelaxation = config.getBoolean(config.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
     int retry = config.getInt(config.BIGQUERY_RETRY_CONFIG);
     long retryWait = config.getLong(config.BIGQUERY_RETRY_WAIT_CONFIG);
-    boolean skipInvalidRows = config.getBoolean(config.SKIP_INVALID_ROWS_CONFIG);
+    boolean skipFailedRows = config.getBoolean(config.SKIP_FAILED_ROWS_CONFIG);
 
     BigQuery bigQuery = getBigQuery();
     if (upsertDelete) {
@@ -361,16 +360,16 @@ public class BigQuerySinkTask extends SinkTask {
                                             retryWait,
                                             autoCreateTables,
                                             mergeBatches.intermediateToDestinationTables(),
-                                            skipInvalidRows);
+                                            skipFailedRows);
     } else if (autoCreateTables || allowNewBigQueryFields || allowRequiredFieldRelaxation) {
       return new AdaptiveBigQueryWriter(bigQuery,
                                         getSchemaManager(),
                                         retry,
                                         retryWait,
                                         autoCreateTables,
-                                        skipInvalidRows);
+                                        skipFailedRows);
     } else {
-      return new SimpleBigQueryWriter(bigQuery, retry, retryWait, skipInvalidRows);
+      return new SimpleBigQueryWriter(bigQuery, retry, retryWait, skipFailedRows);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -370,7 +370,7 @@ public class BigQuerySinkTask extends SinkTask {
                                         autoCreateTables,
                                         skipInvalidRows);
     } else {
-      return new SimpleBigQueryWriter(bigQuery, retry, retryWait);
+      return new SimpleBigQueryWriter(bigQuery, retry, retryWait, skipInvalidRows);
     }
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -322,11 +322,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
                   "incident, this flag can be on to allow dropped column without getting google bq api schema unmatched " +
                   "exception";
 
-  public static final String SKIP_FAILED_ROWS_CONFIG =                         "skipFailedRows";
-  private static final ConfigDef.Type SKIP_FAILED_ROWS_TYPE =                  ConfigDef.Type.BOOLEAN;
-  private static final Boolean SKIP_FAILED_ROWS_DEFAULT =                 false;
-  private static final ConfigDef.Importance SKIP_FAILED_ROWS_IMPORTANCE =      ConfigDef.Importance.LOW;
-  private static final String SKIP_FAILED_ROWS_DOC =
+  public static final String SKIP_INVALID_ROWS_CONFIG =                         "skipInvalidRows";
+  private static final ConfigDef.Type SKIP_INVALID_ROWS_TYPE =                  ConfigDef.Type.BOOLEAN;
+  private static final Boolean SKIP_INVALID_ROWS_DEFAULT =                 false;
+  private static final ConfigDef.Importance SKIP_INVALID_ROWS_IMPORTANCE =      ConfigDef.Importance.LOW;
+  private static final String SKIP_INVALID_ROWS_DOC =
           "NEXT Custom Feature, set this can skip failed rows when write to big query without failing the job";
 
   /**
@@ -535,11 +535,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
             ALLOW_DELETE_COLUMN_IMPORTANCE,
             ALLOW_DELETE_COLUMN_DOC
         ).define(
-            SKIP_FAILED_ROWS_CONFIG,
-            SKIP_FAILED_ROWS_TYPE,
-            SKIP_FAILED_ROWS_DEFAULT,
-            SKIP_FAILED_ROWS_IMPORTANCE,
-            SKIP_FAILED_ROWS_DOC
+            SKIP_INVALID_ROWS_CONFIG,
+            SKIP_INVALID_ROWS_TYPE,
+            SKIP_INVALID_ROWS_DEFAULT,
+            SKIP_INVALID_ROWS_IMPORTANCE,
+            SKIP_INVALID_ROWS_DOC
     );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -34,21 +34,13 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.apache.kafka.connect.sink.SinkConnector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.Optional;
 
 /**
@@ -322,12 +314,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
                   "incident, this flag can be on to allow dropped column without getting google bq api schema unmatched " +
                   "exception";
 
-  public static final String SKIP_INVALID_ROWS_CONFIG =                         "skipInvalidRows";
-  private static final ConfigDef.Type SKIP_INVALID_ROWS_TYPE =                  ConfigDef.Type.BOOLEAN;
-  private static final Boolean SKIP_INVALID_ROWS_DEFAULT =                 false;
-  private static final ConfigDef.Importance SKIP_INVALID_ROWS_IMPORTANCE =      ConfigDef.Importance.LOW;
-  private static final String SKIP_INVALID_ROWS_DOC =
-          "NEXT Custom Feature, set this can skip invalid rows when write to big query without failing the job";
+  public static final String SKIP_FAILED_ROWS_CONFIG =                         "skipFailedRows";
+  private static final ConfigDef.Type SKIP_FAILED_ROWS_TYPE =                  ConfigDef.Type.BOOLEAN;
+  private static final Boolean SKIP_FAILED_ROWS_DEFAULT =                 false;
+  private static final ConfigDef.Importance SKIP_FAILED_ROWS_IMPORTANCE =      ConfigDef.Importance.LOW;
+  private static final String SKIP_FAILED_ROWS_DOC =
+          "NEXT Custom Feature, set this can skip failed rows when write to big query without failing the job";
 
   /**
    * Return a ConfigDef object used to define this config's fields.
@@ -535,11 +527,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
             ALLOW_DELETE_COLUMN_IMPORTANCE,
             ALLOW_DELETE_COLUMN_DOC
         ).define(
-            SKIP_INVALID_ROWS_CONFIG,
-            SKIP_INVALID_ROWS_TYPE,
-            SKIP_INVALID_ROWS_DEFAULT,
-            SKIP_INVALID_ROWS_IMPORTANCE,
-            SKIP_INVALID_ROWS_DOC
+            SKIP_FAILED_ROWS_CONFIG,
+            SKIP_FAILED_ROWS_TYPE,
+            SKIP_FAILED_ROWS_DEFAULT,
+            SKIP_FAILED_ROWS_IMPORTANCE,
+            SKIP_FAILED_ROWS_DOC
     );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -34,13 +34,21 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.apache.kafka.connect.sink.SinkConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Optional;
 
 /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -322,6 +322,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
                   "incident, this flag can be on to allow dropped column without getting google bq api schema unmatched " +
                   "exception";
 
+  public static final String SKIP_INVALID_ROWS_CONFIG =                         "skipInvalidRows";
+  private static final ConfigDef.Type SKIP_INVALID_ROWS_TYPE =                  ConfigDef.Type.BOOLEAN;
+  private static final Boolean SKIP_INVALID_ROWS_DEFAULT =                 false;
+  private static final ConfigDef.Importance SKIP_INVALID_ROWS_IMPORTANCE =      ConfigDef.Importance.LOW;
+  private static final String SKIP_INVALID_ROWS_DOC =
+          "NEXT Custom Feature, set this can skip invalid rows when write to big query without failing the job";
+
   /**
    * Return a ConfigDef object used to define this config's fields.
    *
@@ -527,7 +534,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
             ALLOW_DELETE_COLUMN_DEFAULT,
             ALLOW_DELETE_COLUMN_IMPORTANCE,
             ALLOW_DELETE_COLUMN_DOC
-            );
+        ).define(
+            SKIP_INVALID_ROWS_CONFIG,
+            SKIP_INVALID_ROWS_TYPE,
+            SKIP_INVALID_ROWS_DEFAULT,
+            SKIP_INVALID_ROWS_IMPORTANCE,
+            SKIP_INVALID_ROWS_DOC
+    );
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -59,7 +59,7 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
 
   public static final String BIGQUERY_RETRY_CONFIG =                    "bigQueryRetry";
   private static final ConfigDef.Type BIGQUERY_RETRY_TYPE =             ConfigDef.Type.INT;
-  public static final Integer BIGQUERY_RETRY_DEFAULT =                  3;
+  public static final Integer BIGQUERY_RETRY_DEFAULT =                  0;
   private static final ConfigDef.Validator BIGQUERY_RETRY_VALIDATOR =   ConfigDef.Range.atLeast(0);
   private static final ConfigDef.Importance BIGQUERY_RETRY_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkTaskConfig.java
@@ -59,7 +59,7 @@ public class BigQuerySinkTaskConfig extends BigQuerySinkConfig {
 
   public static final String BIGQUERY_RETRY_CONFIG =                    "bigQueryRetry";
   private static final ConfigDef.Type BIGQUERY_RETRY_TYPE =             ConfigDef.Type.INT;
-  public static final Integer BIGQUERY_RETRY_DEFAULT =                  0;
+  public static final Integer BIGQUERY_RETRY_DEFAULT =                  3;
   private static final ConfigDef.Validator BIGQUERY_RETRY_VALIDATOR =   ConfigDef.Range.atLeast(0);
   private static final ConfigDef.Importance BIGQUERY_RETRY_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -71,8 +71,8 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
                                 int retry,
                                 long retryWait,
                                 boolean autoCreateTables,
-                                boolean skipFailedRows) {
-    super(retry, retryWait, skipFailedRows);
+                                boolean skipInvalidRows) {
+    super(retry, retryWait, skipInvalidRows);
     this.bigQuery = bigQuery;
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -57,7 +57,6 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
   private final BigQuery bigQuery;
   private final SchemaManager schemaManager;
   private final boolean autoCreateTables;
-  private final boolean skipInvalidRows;
 
 
   /**
@@ -72,12 +71,11 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
                                 int retry,
                                 long retryWait,
                                 boolean autoCreateTables,
-                                boolean skipInvalidRows) {
-    super(retry, retryWait);
+                                boolean skipFailedRows) {
+    super(retry, retryWait, skipFailedRows);
     this.bigQuery = bigQuery;
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;
-    this.skipInvalidRows = skipInvalidRows;
   }
 
   private boolean isTableMissingSchema(BigQueryException exception) {
@@ -106,7 +104,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     InsertAllRequest request = null;
 
     try {
-      request = createInsertAllRequest(tableId, rows.values(), skipInvalidRows);
+      request = createInsertAllRequest(tableId, rows.values());
       writeResponse = bigQuery.insertAll(request);
       // Should only perform one schema update attempt.
       if (writeResponse.hasErrors()

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -57,6 +57,8 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
   private final BigQuery bigQuery;
   private final SchemaManager schemaManager;
   private final boolean autoCreateTables;
+  private final boolean skipInvalidRows;
+
 
   /**
    * @param bigQuery Used to send write requests to BigQuery.
@@ -69,11 +71,13 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
                                 SchemaManager schemaManager,
                                 int retry,
                                 long retryWait,
-                                boolean autoCreateTables) {
+                                boolean autoCreateTables,
+                                boolean skipInvalidRows) {
     super(retry, retryWait);
     this.bigQuery = bigQuery;
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;
+    this.skipInvalidRows = skipInvalidRows;
   }
 
   private boolean isTableMissingSchema(BigQueryException exception) {
@@ -102,7 +106,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
     InsertAllRequest request = null;
 
     try {
-      request = createInsertAllRequest(tableId, rows.values());
+      request = createInsertAllRequest(tableId, rows.values(), skipInvalidRows);
       writeResponse = bigQuery.insertAll(request);
       // Should only perform one schema update attempt.
       if (writeResponse.hasErrors()

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -133,8 +133,8 @@ public abstract class BigQueryWriter {
           // if all failed rows fail again, either throw exception to stop the job, or when
           // skipInvalidRows is true, just log failed rows and skip to let the job continue
           if (skipInvalidRows) {
-            logger.info("skipFailedRows-exception:" + new BigQueryConnectException(failedRowsMap));
-            logger.info("skipFailedRows-rows:" + getFailedRows(rows, failedRowsMap.keySet(), table));
+            logger.info("skipInvalidRows-exception:" + new BigQueryConnectException(failedRowsMap));
+            logger.info("skipInvalidRows-rows:" + getFailedRows(rows, failedRowsMap.keySet(), table));
             return;
           }
           throw new BigQueryConnectException(failedRowsMap);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -131,7 +131,7 @@ public abstract class BigQueryWriter {
         } else {
           // throw an exception in case of complete failure
           // if all failed rows fail again, either throw exception to stop the job, or when
-          // skipFailedRows is true, just log failed rows and skip to let the job continue
+          // skipInvalidRows is true, just log failed rows and skip to let the job continue
           if (skipInvalidRows) {
             logger.info("skipFailedRows-exception:" + new BigQueryConnectException(failedRowsMap));
             logger.info("skipFailedRows-rows:" + getFailedRows(rows, failedRowsMap.keySet(), table));

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -89,10 +89,10 @@ public abstract class BigQueryWriter {
    * @return the InsertAllRequest.
    */
   protected InsertAllRequest createInsertAllRequest(PartitionedTableId tableId,
-                                                    Collection<InsertAllRequest.RowToInsert> rows) {
+                                                    Collection<InsertAllRequest.RowToInsert> rows, Boolean skipInvalidRows) {
     return InsertAllRequest.newBuilder(tableId.getFullTableId(), rows)
         .setIgnoreUnknownValues(false)
-        .setSkipInvalidRows(false)
+        .setSkipInvalidRows(skipInvalidRows)
         .build();
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -130,7 +130,11 @@ public abstract class BigQueryWriter {
           retryCount++;
         } else {
           // throw an exception in case of complete failure
+          // if all failed rows fail again, either throw exception to stop the job, or when
+          // skipFailedRows is true, just log failed rows and skip to let the job continue
           if (skipFailedRows) {
+            logger.info("skipFailedRows-exception: {}", mostRecentException);
+            logger.info("skipFailedRows-rows: {}", failedRowsMap);
             return;
           }
           throw new BigQueryConnectException(failedRowsMap);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -63,7 +63,7 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
   @Override
   public Map<Long, List<BigQueryError>> performWriteRequest(PartitionedTableId tableId,
                                                             SortedMap<SinkRecord, InsertAllRequest.RowToInsert> rows) {
-    InsertAllRequest request = createInsertAllRequest(tableId, rows.values());
+    InsertAllRequest request = createInsertAllRequest(tableId, rows.values(), false);
     InsertAllResponse writeResponse = bigQuery.insertAll(request);
     if (writeResponse.hasErrors()) {
       logger.warn(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -44,15 +44,18 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
   private static final Logger logger = LoggerFactory.getLogger(SimpleBigQueryWriter.class);
 
   private final BigQuery bigQuery;
+  private final boolean skipInvalidRows;
+
 
   /**
    * @param bigQuery The object used to send write requests to BigQuery.
    * @param retry How many retries to make in the event of a 500/503 error.
    * @param retryWait How long to wait in between retries.
    */
-  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait) {
+  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait, boolean skipInvalidRows) {
     super(retry, retryWait);
     this.bigQuery = bigQuery;
+    this.skipInvalidRows = skipInvalidRows;
   }
 
   /**
@@ -63,7 +66,7 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
   @Override
   public Map<Long, List<BigQueryError>> performWriteRequest(PartitionedTableId tableId,
                                                             SortedMap<SinkRecord, InsertAllRequest.RowToInsert> rows) {
-    InsertAllRequest request = createInsertAllRequest(tableId, rows.values(), false);
+    InsertAllRequest request = createInsertAllRequest(tableId, rows.values(), skipInvalidRows);
     InsertAllResponse writeResponse = bigQuery.insertAll(request);
     if (writeResponse.hasErrors()) {
       logger.warn(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -51,8 +51,8 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
    * @param retry How many retries to make in the event of a 500/503 error.
    * @param retryWait How long to wait in between retries.
    */
-  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait, boolean skipFailedRows) {
-    super(retry, retryWait, skipFailedRows);
+  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait, boolean skipInvalidRows) {
+    super(retry, retryWait, skipInvalidRows);
     this.bigQuery = bigQuery;
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -44,7 +44,6 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
   private static final Logger logger = LoggerFactory.getLogger(SimpleBigQueryWriter.class);
 
   private final BigQuery bigQuery;
-  private final boolean skipInvalidRows;
 
 
   /**
@@ -52,10 +51,9 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
    * @param retry How many retries to make in the event of a 500/503 error.
    * @param retryWait How long to wait in between retries.
    */
-  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait, boolean skipInvalidRows) {
-    super(retry, retryWait);
+  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait, boolean skipFailedRows) {
+    super(retry, retryWait, skipFailedRows);
     this.bigQuery = bigQuery;
-    this.skipInvalidRows = skipInvalidRows;
   }
 
   /**
@@ -66,7 +64,7 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
   @Override
   public Map<Long, List<BigQueryError>> performWriteRequest(PartitionedTableId tableId,
                                                             SortedMap<SinkRecord, InsertAllRequest.RowToInsert> rows) {
-    InsertAllRequest request = createInsertAllRequest(tableId, rows.values(), skipInvalidRows);
+    InsertAllRequest request = createInsertAllRequest(tableId, rows.values());
     InsertAllResponse writeResponse = bigQuery.insertAll(request);
     if (writeResponse.hasErrors()) {
       logger.warn(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -54,12 +54,12 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
                                     long retryWait,
                                     boolean autoCreateTables,
                                     Map<TableId, TableId> intermediateToDestinationTables,
-                                    boolean skipInvalidRows) {
+                                    boolean skipFailedRows) {
     // Hardcode autoCreateTables to true in the superclass so that intermediate tables will be
     // automatically created
     // The super class will handle all of the logic for writing to, creating, and updating
     // intermediate tables; this class will handle logic for creating/updating the destination table
-    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true, skipInvalidRows);
+    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true, skipFailedRows);
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;
     this.intermediateToDestinationTables = intermediateToDestinationTables;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -36,6 +36,7 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
   private final boolean autoCreateTables;
   private final Map<TableId, TableId> intermediateToDestinationTables;
 
+
   /**
    * @param bigQuery Used to send write requests to BigQuery.
    * @param schemaManager Used to update BigQuery tables.
@@ -52,12 +53,13 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
                                     int retry,
                                     long retryWait,
                                     boolean autoCreateTables,
-                                    Map<TableId, TableId> intermediateToDestinationTables) {
+                                    Map<TableId, TableId> intermediateToDestinationTables,
+                                    boolean skipInvalidRows) {
     // Hardcode autoCreateTables to true in the superclass so that intermediate tables will be
     // automatically created
     // The super class will handle all of the logic for writing to, creating, and updating
     // intermediate tables; this class will handle logic for creating/updating the destination table
-    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true);
+    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true, skipInvalidRows);
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;
     this.intermediateToDestinationTables = intermediateToDestinationTables;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -54,12 +54,12 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
                                     long retryWait,
                                     boolean autoCreateTables,
                                     Map<TableId, TableId> intermediateToDestinationTables,
-                                    boolean skipFailedRows) {
+                                    boolean skipInvalidRows) {
     // Hardcode autoCreateTables to true in the superclass so that intermediate tables will be
     // automatically created
     // The super class will handle all of the logic for writing to, creating, and updating
     // intermediate tables; this class will handle logic for creating/updating the destination table
-    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true, skipFailedRows);
+    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true, skipInvalidRows);
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;
     this.intermediateToDestinationTables = intermediateToDestinationTables;


### PR DESCRIPTION
Will do test on dev before merge
-- insert invalid rows in dev, the connector starts to fail
--delete the invalid rows, the connector continues to fail
--after this fix, the bq count is the same as db (we have already delete invalid row in db)

<img width="1786" alt="Screen Shot 2021-03-05 at 9 58 06 AM" src="https://user-images.githubusercontent.com/68567498/110154701-69987700-7d99-11eb-8423-f3f0b878b4f2.png">

