### PR TITLE
Use `batch` priority when clearing intermediate tables

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -155,7 +155,8 @@ public class MergeQueries {
     logger.trace("Clearing batches from {} on back from {}", batchNumber, intTable(intermediateTable));
     String batchClearQuery = batchClearQuery(intermediateTable, batchNumber);
     logger.trace(batchClearQuery);
-    bigQuery.query(QueryJobConfiguration.of(batchClearQuery));
+    // Run in `batch` priority to reduce the number of concurrent `interactive` queries, of which count against BigQuery limits.
+    bigQuery.query(QueryJobConfiguration.newBuilder(batchClearQuery).setPriority(QueryJobConfiguration.Priority.BATCH).build());
   }
 
   @VisibleForTesting


### PR DESCRIPTION
For configurations with many bigquery connectors, such as our debezium
data pipelines to bigquery that replicate 100s of tables, we'd like to
reduce the number of `interactive` queries running as to reduce the
likelyhood of hitting concurrent query limits.

Since the intermediate table clearing is done on a best effort basis
and since the code is already built to handle stale data in the table,
(including cases where the data is in the temp streaming buffer),
we can safely queue up deletes in `batch` mode.
